### PR TITLE
Increase entity size config limit.  Default is too small.  

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ var express = require('express'),
 
 app.use(iefix({ contentType: 'application/x-www-form-urlencoded' }));
 app.use(bodyParser.text({ 'type': 'application/hal+json', 'limit' : '50mb' }));
+app.use(bodyParser.text({ 'type': 'application/json', 'limit' : '50mb' }));
 app.use(halParser);
 app.use(requireHttps);
 app.use(cors());

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ var express = require('express'),
     app = module.exports = express();
 
 app.use(iefix({ contentType: 'application/x-www-form-urlencoded' }));
-app.use(bodyParser.text({ 'type': 'application/hal+json' }));
+app.use(bodyParser.text({ 'type': 'application/hal+json', 'limit' : '50mb' }));
 app.use(halParser);
 app.use(requireHttps);
 app.use(cors());


### PR DESCRIPTION
 Increase entity size config limit.  Default is too small.  VAN API can
    return larger responses than will fit, which causes a 413 to OSDI clients
    even though the VAN api call was fine.  Increased limit.