### PR TITLE
Fix/aep person signup href link

### DIFF
--- a/routes/apiRoot.js
+++ b/routes/apiRoot.js
@@ -27,7 +27,7 @@ function apiRoot(req, res) {
         'title': 'The collection of people in the system'
       },
       'osdi:person_signup_helper': {
-          'href': root + 'people/person_signup',
+          'href': root + 'people/person_signup_helper',
           'title': 'The person signup helper for the system'
       }
     }


### PR DESCRIPTION
The link in the AEP for the person_signup helper was wrong.  As defined in the node app, the route is actually /people/person_signup_helper not /people/person_signup